### PR TITLE
Add missing import

### DIFF
--- a/utils/foldseek_util.py
+++ b/utils/foldseek_util.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 import json
 import numpy as np


### PR DESCRIPTION
Hello! I added the missing import (`re`), which is used in the `extract_plddt()` function. 

Thank you again for this interesting work.