### PR TITLE
Resolve dependency issues involving protobuf and setuptools

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -10,3 +10,4 @@ pip install lmdb==1.4.1
 pip install torchmetrics==0.9.3
 pip install pandas==2.1.1
 pip install fair-esm==2.0.0
+pip install protobuf<=3.20.1

--- a/environment.sh
+++ b/environment.sh
@@ -11,3 +11,4 @@ pip install torchmetrics==0.9.3
 pip install pandas==2.1.1
 pip install fair-esm==2.0.0
 pip install protobuf<=3.20.1
+pip install setuptools<81


### PR DESCRIPTION
Hello! I wrote a pull request pinning the versions of `protobuf` and `setuptools` to address some dependency issues.

1. Regarding `protobuf`

The following error was raised: `TypeError: Descriptors cannot not be created directly.` Looking at the stack trace suggests that the error is caused by SaProt's required version of `wandb` having a dependency issue with `protobuf` (similar to [this issue](https://github.com/wandb/wandb/issues/9674)). Downgrading `protobuf` to a version <= 3.20.1 solves the issue.

2. Regarding `setuptools`

The following warning was displayed: `UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early
 as 2025-11-30. Refrain from using this package or pin to Setuptools<81.` (similar to [this issue](https://github.com/yt-dlp/yt-dlp/issues/13311)). 

Although currently this does not raise an error since the latest version of `setuptools` is `80.9.0`, maybe it's a good idea to preemptively pin the version to (hopefully) avoid dependency problems in the future.

Also, thanks again for this amazing work! 